### PR TITLE
chore(coverage): add code coverage using codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ pids
 
 # Dependency directories
 node_modules/
+
+# Coverage
+coverage/
+
+.tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ node_js:
   - "10"
   - "8"
   - "6"
+before_install:
+  - npm i -g npm
+install:
+  - travis_wait npm ci
+  - npm install -g codecov
+script:
+  - npm run test
+  - codecov
 cache:
   directories:
     - ~/.npm

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# findall-pkg-mgr [![Build Status](https://travis-ci.org/hemal7735/findall-pkg-mgr.svg?branch=master)](https://travis-ci.org/hemal7735/findall-pkg-mgr)
+# findall-pkg-mgr [![Build Status](https://travis-ci.org/hemal7735/findall-pkg-mgr.svg?branch=master)](https://travis-ci.org/hemal7735/findall-pkg-mgr) [![codecov](https://codecov.io/gh/hemal7735/findall-pkg-mgr/branch/master/graph/badge.svg)](https://codecov.io/gh/hemal7735/findall-pkg-mgr)
 
 It finds all package-managers installed in the system. It finds them without requiring any external dependency.
 

--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
   "homepage": "https://github.com/hemal7735/findall-pkg-mgr#readme",
   "devDependencies": {
     "jest": "^23.6.0"
+  },
+  "jest": {
+    "coverageDirectory": "./coverage/",
+    "collectCoverage": true
   }
 }


### PR DESCRIPTION
* Need to set `CODECOV_TOKEN="<codecov-token>"` environment variable in Travis to get this up and running

@hemal7735 Please go to https://codecov.io/gh/hemal7745/findall-pkg-mgr to get started. Do let me know if you find something missing or awry